### PR TITLE
NI with JFR and JMX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ In addition, you will need either a PostgreSQL database, or Docker to run one.
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
 been set, and that a JDK 11+ `java` command is on the path.
 
+[Mandrel 23+](https://github.com/graalvm/mandrel/releases) is recommended as the GraalVM implementation for this demo.
+
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image)
 for help setting up your environment.
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -13,3 +13,5 @@ podman build -t quay.io/andrewazores/quarkus-quickstart-hibernate:jvm-latest -f 
 
 ./mvnw clean package -Dnative -DskipTests -Dquarkus.native.monitoring=jfr,jmxserver,jmxclient,jvmstat
 podman build -t quay.io/roberttoyonaga/jmx:cryostatquarkus -f src/main/docker/Dockerfile.native .
+
+podman image prune -f

--- a/build-images.sh
+++ b/build-images.sh
@@ -7,5 +7,5 @@ set -e
 podman build -t quay.io/andrewazores/quarkus-quickstart-hibernate:jvm-latest -f src/main/docker/Dockerfile.jvm .
 
 
-./mvnw -Dnative clean package
-podman build -t quay.io/andrewazores/quarkus-quickstart-hibernate:native-latest -f src/main/docker/Dockerfile.native .
+./mvnw clean package -Dnative -DskipTests -Dquarkus.native.monitoring=jfr,jmxserver,jmxclient,jvmstat
+podman build -t quay.io/roberttoyonaga/jmx:cryostatquarkus -f src/main/docker/Dockerfile.native .

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,9 +3,13 @@
 set -x
 set -e
 
+if [ -z "${GRAALVM_HOME}" ]; then
+  echo "\$GRAALVM_HOME is not set. This build is likely to fail." >&2
+  sleep 3
+fi
+
 ./mvnw clean package
 podman build -t quay.io/andrewazores/quarkus-quickstart-hibernate:jvm-latest -f src/main/docker/Dockerfile.jvm .
-
 
 ./mvnw clean package -Dnative -DskipTests -Dquarkus.native.monitoring=jfr,jmxserver,jmxclient,jvmstat
 podman build -t quay.io/roberttoyonaga/jmx:cryostatquarkus -f src/main/docker/Dockerfile.native .

--- a/compose-quarkus.yml
+++ b/compose-quarkus.yml
@@ -32,6 +32,13 @@ services:
       db2:
         condition: service_healthy
     image: quay.io/roberttoyonaga/jmx:cryostatquarkus
+    command: >
+      "./application"
+      "-Dquarkus.http.host=0.0.0.0"
+      "-Dcom.sun.management.jmxremote.port=9092"
+      "-Dcom.sun.management.jmxremote.ssl=false"
+      "-Dcom.sun.management.jmxremote.authenticate=false"
+      "-Djava.rmi.server.hostname=quarkus-native"
     hostname: quarkus-native
     labels:
       - io.cryostat.discovery=true

--- a/compose-quarkus.yml
+++ b/compose-quarkus.yml
@@ -31,11 +31,11 @@ services:
     depends_on:
       db2:
         condition: service_healthy
-    image: quay.io/andrewazores/quarkus-quickstart-hibernate:native-latest
+    image: quay.io/roberttoyonaga/jmx:cryostatquarkus
     hostname: quarkus-native
     labels:
       - io.cryostat.discovery=true
-      - io.cryostat.jmxPort=9092 # TODO, need to compile the image with this supported + enabled
+      - io.cryostat.jmxPort=9092
     expose:
       - 8081
       - 9092

--- a/src/main/docker/Dockerfile.native
+++ b/src/main/docker/Dockerfile.native
@@ -24,4 +24,4 @@ COPY --chown=1001:root target/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Dcom.sun.management.jmxremote.port=9092", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false"]

--- a/src/main/docker/Dockerfile.native
+++ b/src/main/docker/Dockerfile.native
@@ -24,4 +24,4 @@ COPY --chown=1001:root target/*-runner /work/application
 EXPOSE 8080
 USER 1001
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Dcom.sun.management.jmxremote.port=9092", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
Build a native image executable of the hibernate-orm quickstart with JFR and JMX support. Made appropriate changes here. For some reason when I run demo.bash I cannot see any targets in the topology view other than Cryostat itself (with or without my changes). 

```
Jun 15, 2023 5:38:17 PM io.cryostat.core.log.Logger info
INFO: Connection for service:jmx:rmi:///jndi/rmi://quarkus-jvm:9090/jmxrmi closed
Jun 15, 2023 5:38:17 PM io.cryostat.core.log.Logger error
SEVERE: Exception thrown
org.openjdk.jmc.rjmx.ConnectionException caused by java.io.IOException: Failed to retrieve RMIServer stub: javax.naming.ConfigurationException [Root exception is java.rmi.UnknownHostException: Unknown host: quarkus-jvm; nested exception is: 
        java.net.UnknownHostException: quarkus-jvm]
        at org.openjdk.jmc.rjmx.internal.RJMXConnection.connect(RJMXConnection.java:345)
        at io.cryostat.core.net.JFRJMXConnection.attemptConnect(JFRJMXConnection.java:445)
        at io.cryostat.core.net.JFRJMXConnection.connect(JFRJMXConnection.java:401)
        at io.cryostat.core.net.JFRJMXConnection.getJvmId(JFRJMXConnection.java:204)
        at io.cryostat.net.TargetConnectionManager.lambda$executeConnectedTaskAsync$2(TargetConnectionManager.java:153)
        at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
        at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
Caused by: java.io.IOException: Failed to retrieve RMIServer stub: javax.naming.ConfigurationException [Root exception is java.rmi.UnknownHostException: Unknown host: quarkus-jvm; nested exception is: 
        java.net.UnknownHostException: quarkus-jvm]
        at java.management.rmi/javax.management.remote.rmi.RMIConnector.connect(RMIConnector.java:370)
        at org.openjdk.jmc.rjmx.internal.RJMXConnection.connectJmxConnector(RJMXConnection.java:575)
        at org.openjdk.jmc.rjmx.internal.RJMXConnection.establishConnection(RJMXConnection.java:552)
        at org.openjdk.jmc.rjmx.internal.RJMXConnection.connect(RJMXConnection.java:338)
        ... 11 more
Caused by: javax.naming.ConfigurationException [Root exception is java.rmi.UnknownHostException: Unknown host: quarkus-jvm; nested exception is: 
        java.net.UnknownHostException: quarkus-jvm]
        at jdk.naming.rmi/com.sun.jndi.rmi.registry.RegistryContext.lookup(RegistryContext.java:138)
        at java.naming/com.sun.jndi.toolkit.url.GenericURLContext.lookup(GenericURLContext.java:220)
        at java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
        at java.management.rmi/javax.management.remote.rmi.RMIConnector.findRMIServerJNDI(RMIConnector.java:1839)
        at java.management.rmi/javax.management.remote.rmi.RMIConnector.findRMIServer(RMIConnector.java:1813)
        at java.management.rmi/javax.management.remote.rmi.RMIConnector.connect(RMIConnector.java:302)
        ... 14 more
Caused by: java.rmi.UnknownHostException: Unknown host: quarkus-jvm; nested exception is: 
        java.net.UnknownHostException: quarkus-jvm
        at java.rmi/sun.rmi.transport.tcp.TCPEndpoint.newSocket(TCPEndpoint.java:623)
        at java.rmi/sun.rmi.transport.tcp.TCPChannel.createConnection(TCPChannel.java:217)
        at java.rmi/sun.rmi.transport.tcp.TCPChannel.newConnection(TCPChannel.java:204)
        at java.rmi/sun.rmi.server.UnicastRef.newCall(UnicastRef.java:344)
        at java.rmi/sun.rmi.registry.RegistryImpl_Stub.lookup(RegistryImpl_Stub.java:116)
        at jdk.naming.rmi/com.sun.jndi.rmi.registry.RegistryContext.lookup(RegistryContext.java:134)
        ... 19 more
Caused by: java.net.UnknownHostException: quarkus-jvm
        at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:567)
        at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
        at java.base/java.net.Socket.connect(Socket.java:633)
        at java.base/java.net.Socket.connect(Socket.java:583)
        at java.base/java.net.Socket.<init>(Socket.java:507)
        at java.base/java.net.Socket.<init>(Socket.java:287)
        at java.rmi/sun.rmi.transport.tcp.TCPDirectSocketFactory.createSocket(TCPDirectSocketFactory.java:40)
        at java.rmi/sun.rmi.transport.tcp.TCPEndpoint.newSocket(TCPEndpoint.java:620)
        ... 24 more
```

no errors related to `quarkus-native`, but it still doesn't get discovered by Cryostat. I'm probably missing something silly. 